### PR TITLE
Respect loading order to execute actions & pipelines

### DIFF
--- a/src/ActionProxy.php
+++ b/src/ActionProxy.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Runtime\Workflow;
+
+use Kiboko\Component\Runtime\Action\Console as ActionConsoleRuntime;
+use Kiboko\Component\State;
+use Kiboko\Contract\Action\ExecutingActionInterface;
+use Kiboko\Contract\Satellite\RunnableInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class ActionProxy implements RunnableInterface
+{
+    /** @var list<callable> */
+    private array $queuedCalls = [];
+
+    public function __construct(
+        callable $factory,
+        private readonly ConsoleOutput $output,
+        private readonly ExecutingActionInterface $action,
+        private readonly State\StateOutput\Workflow $state,
+        private readonly string $filename,
+    ) {
+        $this->queuedCalls[] = static function (ActionConsoleRuntime $runtime) use ($factory): void {
+            $factory($runtime);
+        };
+    }
+
+    public function run(int $interval = 1000): int
+    {
+        $runtime = new ActionConsoleRuntime($this->output, $this->action, $this->state->withAction($this->filename));
+
+        foreach ($this->queuedCalls as $queuedCall) {
+            $queuedCall($runtime);
+        }
+
+        $this->queuedCalls = [];
+
+        return $runtime->run($interval);
+    }
+}

--- a/src/Console.php
+++ b/src/Console.php
@@ -6,11 +6,10 @@ namespace Kiboko\Component\Runtime\Workflow;
 
 use Kiboko\Component\Action\Action;
 use Kiboko\Component\Pipeline\Pipeline;
-use Kiboko\Component\Runtime\Action\ActionRuntimeInterface;
-use Kiboko\Component\Runtime\Action\Console as ActionConsoleRuntime;
 use Kiboko\Component\Runtime\Pipeline\PipelineRuntimeInterface;
 use Kiboko\Component\State;
 use Kiboko\Contract\Pipeline\PipelineRunnerInterface;
+use Kiboko\Contract\Satellite\RunnableInterface;
 use Kiboko\Contract\Satellite\RunnableInterface as JobRunnableInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
@@ -37,13 +36,13 @@ final class Console implements WorkflowRuntimeInterface
         return new PipelineProxy($factory, $this->output, $pipeline, $this->state, basename($filename));
     }
 
-    public function loadAction(string $filename): ActionRuntimeInterface
+    public function loadAction(string $filename): RunnableInterface
     {
         $factory = require $filename;
 
         $action = new Action();
 
-        return $factory(new ActionConsoleRuntime($this->output, $action, $this->state->withAction(basename($filename))));
+        return new ActionProxy($factory, $this->output, $action, $this->state, basename($filename));
     }
 
     public function job(JobRunnableInterface $job): self

--- a/src/WorkflowRuntimeInterface.php
+++ b/src/WorkflowRuntimeInterface.php
@@ -7,6 +7,4 @@ namespace Kiboko\Component\Runtime\Workflow;
 use Kiboko\Contract\Pipeline\SchedulingInterface;
 use Kiboko\Contract\Satellite\RunnableInterface;
 
-interface WorkflowRuntimeInterface extends SchedulingInterface, RunnableInterface
-{
-}
+interface WorkflowRuntimeInterface extends SchedulingInterface, RunnableInterface {}


### PR DESCRIPTION
fix: instead of `loadAction` directly returning the factory (which incorrectly runs it immediately),
put the action in an ActionProxy to run it later, in `run`, along with the other jobs